### PR TITLE
Update invocation to fix startup error

### DIFF
--- a/.changeset/thin-geckos-sniff.md
+++ b/.changeset/thin-geckos-sniff.md
@@ -1,5 +1,0 @@
----
-"dynohot": patch
----
-
-Additional named indirect export fixes

--- a/.changeset/thin-geckos-sniff.md
+++ b/.changeset/thin-geckos-sniff.md
@@ -1,0 +1,5 @@
+---
+"dynohot": patch
+---
+
+Additional named indirect export fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # dynohot
 
+## 2.1.1
+
+### Patch Changes
+
+- 0031498: Additional named indirect export fixes
+
 ## 2.1.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,15 @@
 ### Minor Changes
 
 - 3252988: Fix indirect exports from adapter modules
+
+## 2.0.1
+
+### Patch Changes
+
+- 8c6e230: Bundler resolution mode type fixes
+
+## 2.0.0
+
+### Major Changes
+
+- a11fa40: Resolution overhaul

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ export const now = new Date();
 ```
 $ while true; do sleep 1; touch now.js; done &
 
-$ node --import dynohot/register main.js
+$ node --import dynohot main.js
 [hot] Loaded 1 new module, reevaluated 0 existing modules in 2ms.
 2023-08-07T23:49:45.693Z
 [hot] Loaded 1 new module, reevaluated 0 existing modules in 2ms.

--- a/__tests__/link.ts
+++ b/__tests__/link.ts
@@ -168,3 +168,35 @@ await test("re-export from adapter module", async () => {
 		assert.strictEqual(utility.identifier, "hello world");`);
 	await main.dispatch();
 });
+
+await test("explicit shadowed export", async () => {
+	const one = new TestModule(() =>
+		"export const id = 1;");
+	const two = new TestModule(() =>
+		`export * from ${one};
+		export const id = 2;`);
+	const main = new TestModule(() =>
+		`import * as utility from ${two};
+		assert.strictEqual(utility.id, 2);`);
+	await main.dispatch();
+});
+
+await test("duplicate re-export", async () => {
+	const dep = new TestModule(() =>
+		"export const id = 1;");
+	const barrel = new TestModule(() =>
+		`export { id, id } from ${dep};`);
+	await assert.rejects(() => barrel.dispatch());
+});
+
+await test("named export of module namespace", async () => {
+	const one = new TestModule(() =>
+		"export const id = 1;");
+	const two = new TestModule(() =>
+		`import * as ns from ${one};
+		export { ns };`);
+	const main = new TestModule(() =>
+		`import * as two from ${two};
+		assert.strictEqual(two.ns.id, 1);`);
+	await main.dispatch();
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "dynohot",
 	"type": "module",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"exports": {
 		".": "./dist/loader/dispatch.js",
 		"./loader": "./dist/loader/loader.js",


### PR DESCRIPTION
Fixes #19, the previous version fails startup with the following issue on latest NodeJS and v2.1.1 tag:

```
TypeError: Cannot read properties of undefined (reading 'accept')
```